### PR TITLE
Update README.txt

### DIFF
--- a/Actors/Items/Inventory/cdi_marines_items.txt
+++ b/Actors/Items/Inventory/cdi_marines_items.txt
@@ -151,7 +151,7 @@ ACTOR MarineMedicBeacon : MarineDBFGBeacon
 {
  Inventory.Icon "BCMDZ0"
  Inventory.PickupSound "Beacon/Pickup"
- Inventory.PickupMessage "DrBeacon2Pickup"
+ Inventory.PickupMessage "$DrBeacon2Pickup"
  Tag "$DrBeacon2"
  States
  {

--- a/README.txt
+++ b/README.txt
@@ -7,9 +7,9 @@ Clusterweapons, Clusteraddons and main Nexus content.
 
 This file also includes CF/HEM/ILCA/DUST/HPBAR
 
-More info: [redacted]
-Official Discord server: [redacted]
+Official Discord server: https://discord.com/invite/dwsWCn4WUC
 
+Clusterfuck Wiki: https://complex-cf.fandom.com/wiki/Complex_CF
 
 !PLEASE NOTE!
 


### PR DESCRIPTION
Adds url for the discord server + wiki in the readme
Fixed pick up message for the medic beacon, I don't know if those are being dropped by any monster, if so they need to be looked at, because they don't appear for few seconds when used.